### PR TITLE
Add verify_compact for signatures

### DIFF
--- a/src/libsecp256k1.app.src
+++ b/src/libsecp256k1.app.src
@@ -6,7 +6,7 @@
 {application, libsecp256k1,
  [
   {description, "Erlang NIF bindings for the the libsecp256k1 library"},
-  {vsn, "0.1.2"},
+  {vsn, "0.1.3"},
   {maintainers, ["Matthew Branton", "Geoffrey Hayes"]},
   {links, [{"Github", "https://github.com/exthereum/libsecp256k1"}]},
   {licenses, ["MIT"]},

--- a/src/libsecp256k1.erl
+++ b/src/libsecp256k1.erl
@@ -26,6 +26,7 @@
 		 ecdsa_sign/4,
 		 ecdsa_verify/3,
 		 ecdsa_sign_compact/4,
+		 ecdsa_verify_compact/3,
 		 ecdsa_recover_compact/4]).
 
 -on_load(init/0).
@@ -113,6 +114,10 @@ ecdsa_verify(_, _, _) ->
 
 -spec ecdsa_sign_compact(binary(), private_key(), atom(), binary()) -> {ok, signature(), recovery_id()} | {error, string()}.
 ecdsa_sign_compact(_, _, _, _) ->
+	erlang:nif_error({error, not_loaded}).
+
+-spec ecdsa_verify_compact(binary(), signature(), public_key()) -> ok | error.
+ecdsa_verify_compact(_, _, _) ->
 	erlang:nif_error({error, not_loaded}).
 
 -spec ecdsa_recover_compact(binary(), signature(), compression(), recovery_id()) -> {ok, public_key()} | {error, string()}.

--- a/test/libsecp256k1_tests.erl
+++ b/test/libsecp256k1_tests.erl
@@ -67,7 +67,8 @@ compact_signing() ->
 	{ok, Pubkey} = libsecp256k1:ec_pubkey_create(A, uncompressed),
 	{ok, Signature, RecoveryID} = libsecp256k1:ecdsa_sign_compact(Msg, A, default, <<>>),
 	{ok, RecoveredKey} = libsecp256k1:ecdsa_recover_compact(Msg, Signature, uncompressed, RecoveryID),
-	?assertEqual(Pubkey, RecoveredKey).
+	?assertEqual(Pubkey, RecoveredKey),
+	?assertEqual(ok, libsecp256k1:ecdsa_verify_compact(Msg, Signature, Pubkey)).
 
 sha256() ->
 	A = crypto:strong_rand_bytes(64),


### PR DESCRIPTION
This patch adds signature recover compact. When using compact signatures, the current API has no direct interface. This patch adds a simple new function to allow a user to verify compact signatures.