### PR TITLE
update to newer secp256k1 - libssl 1.1 compatibility

### DIFF
--- a/c_src/build_deps.sh
+++ b/c_src/build_deps.sh
@@ -14,7 +14,7 @@ case "$1" in
 
     (test -d secp256k1 || git clone https://github.com/bitcoin/secp256k1)
 
-    (cd secp256k1 && git reset --hard 5a91bd768faaa974e00301e662fd8f2aa75a122a &&  ./autogen.sh && ./configure --enable-module-recovery && make)
+    (cd secp256k1 && git reset --hard d33352151699bd7598b868369dace092f7855740 &&  ./autogen.sh && ./configure --enable-module-recovery && make)
 	#(cd secp256k1 &&  ./autogen.sh && ./configure --enable-module-recovery && make)
     ;;
 esac

--- a/c_src/libsecp256k1_nif.c
+++ b/c_src/libsecp256k1_nif.c
@@ -63,12 +63,12 @@ dsha256(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 	// Create a NIF binary object with a 32 byte return
 	output = enif_make_new_binary(env, 32, &r);
 
-    secp256k1_sha256_t hasher;
+    secp256k1_sha256 hasher;
     secp256k1_sha256_initialize(&hasher);
     secp256k1_sha256_write(&hasher, (const unsigned char*)(p.data), p.size);
     secp256k1_sha256_finalize(&hasher, output);
 
-    secp256k1_sha256_t hasher2;
+    secp256k1_sha256 hasher2;
     secp256k1_sha256_initialize(&hasher2);
     secp256k1_sha256_write(&hasher2, (const unsigned char*)(output), 32);
     secp256k1_sha256_finalize(&hasher2, output);
@@ -90,7 +90,7 @@ sha256(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
 	// Create a NIF binary object with a 32 byte return
 	output = enif_make_new_binary(env, 32, &r);
-    secp256k1_sha256_t hasher;
+    secp256k1_sha256 hasher;
     secp256k1_sha256_initialize(&hasher);
     secp256k1_sha256_write(&hasher, (const unsigned char*)(p.data), p.size);
     secp256k1_sha256_finalize(&hasher, output);
@@ -115,7 +115,7 @@ hmac_sha256(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
 
 	// Create a NIF binary object with a 32 byte return
 	output = enif_make_new_binary(env, 32, &r);
-    secp256k1_hmac_sha256_t hasher;
+    secp256k1_hmac_sha256 hasher;
     secp256k1_hmac_sha256_initialize(&hasher, (const unsigned char*)(key.data), key.size);
     secp256k1_hmac_sha256_write(&hasher, (const unsigned char*)(input.data), input.size);
     secp256k1_hmac_sha256_finalize(&hasher, output);


### PR DESCRIPTION
Useful since libssl 1.1 is used by default on Ubuntu 18.04 Bionic Beaver.