### PR TITLE
Link Libraries after Objects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ else
 	LIB_PATH = deps/libsecp256k1
 endif
 
-CFLAGS += -I$LIB_PATH/src
+CFLAGS += -I$(LIB_PATH)/src
 
 ifneq ($(OS),Windows_NT)
 	CFLAGS += -fPIC
@@ -28,7 +28,7 @@ all: priv/libsecp256k1_nif.so
 
 priv/libsecp256k1_nif.so: c_src/libsecp256k1_nif.c
 	c_src/build_deps.sh
-	$(CC) $(CFLAGS) -shared $(LDFLAGS) -o $@ c_src/libsecp256k1_nif.c
+	$(CC) $(CFLAGS) -shared -o $@ c_src/libsecp256k1_nif.c $(LDFLAGS)
 
 clean:
 	$(MIX) clean

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,7 @@ defmodule Libsecp256k1.Mixfile do
   def project do
     [
       app: :libsecp256k1,
-      version: "0.1.9",
+      version: "0.1.10",
       language: :erlang,
       description: "Erlang NIF bindings for the the libsecp256k1 library",
       package: [


### PR DESCRIPTION
This patch changes the order of the cc command so that we add the build target (.c) file before we link the gmp library (-lgmp). The alternate ordering was breaking the build on musl. Additionally, we fix a variable substitution that was missing parens (thanks make syntax!).