### PR TITLE
fix: prevent privkey modified by ec_seckey_verify method

### DIFF
--- a/c_src/libsecp256k1_nif.c
+++ b/c_src/libsecp256k1_nif.c
@@ -165,15 +165,8 @@ ec_seckey_verify(ErlNifEnv* env, int argc, const ERL_NIF_TERM argv[])
     }
 
     if (privkey.size != 32) {
-    	return enif_make_badarg(env);
+		return error_result(env, "Private key size != 32 bytes");
 	}
-
-	secp256k1_scalar_set_b32(&key, b32, &overflow);
-	if (overflow || secp256k1_scalar_is_zero(&key)) {
-		return enif_make_int(env, 0);
-	}
-
-	secp256k1_scalar_get_b32(privkey.data, &key);
 
     result = secp256k1_ec_seckey_verify(ctx, privkey.data);
     return atom_from_result(env, result);


### PR DESCRIPTION
`ec_seckey_verify` method would change the value of the private key inputed as argument. For example:

```elixir
iex(2)> {pubkey, privkey} = :crypto.generate_key(:ecdh, :secp256k1)
{<<4, 93, 21, 247, 9, 127, 33, 229, 202, 110, 246, 105, 76, 192, 12, 215, 65,
   232, 238, 37, 88, 110, 2, 89, 17, 59, 158, 227, 95, 183, 115, 120, 225, 144,
   170, 19, 9, 196, 68, 64, 96, 90, 78, 173, 112, 46, 89, 88, 71, ...>>,
 <<3, 185, 32, 160, 132, 78, 43, 141, 96, 195, 72, 104, 253, 206, 48, 64, 194,
   120, 210, 131, 182, 147, 112, 208, 189, 114, 155, 211, 62, 248, 22, 158>>}
iex(3)> :ok = :libsecp256k1.ec_seckey_verify(privkey)
:ok
iex(4)> privkey
<<142, 0, 13, 110, 86, 234, 133, 174, 24, 0, 0, 0, 0, 0, 0, 0, 128, 130, 232,
  24, 0, 0, 0, 0, 224, 54, 85, 26, 0, 0, 0, 0>>
```
