### PR TITLE
Fix windows compilation issue with spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 MIX = mix
 
 ERLANG_PATH = $(shell erl -eval 'io:format("~s", [lists:concat([code:root_dir(), "/erts-", erlang:system_info(version), "/include"])])' -s init stop -noshell)
-CFLAGS += -I$(ERLANG_PATH)
+CFLAGS += -I"$(ERLANG_PATH)"
 CFLAGS += -I c_src/secp256k1 -I c_src/secp256k1/src -I c_src/secp256k1/include
 
 ifeq ($(wildcard deps/libsecp256k1),)


### PR DESCRIPTION
When erlang is in a folder with space in it "C:/Program Files/erlang/...." it will fail without the quotes.